### PR TITLE
Update __init__.py

### DIFF
--- a/pyflowater/__init__.py
+++ b/pyflowater/__init__.py
@@ -40,6 +40,7 @@ class PyFlo(object):
 
         self._auth_token = None
         self._username = username
+        self._password = None # call save_password() if you want to save it
 
         self.login_with_password(password)
 


### PR DESCRIPTION
previously if the PyFlo object persisted beyond the expiration time of the token and save_password() was not called, login() would raise
  AttributeError: 'PyFlo' object has no attribute '_password'
now login() returns silently without doing anything.