### PR TITLE
Add retry for get_real_time_listener

### DIFF
--- a/pyflowater/__init__.py
+++ b/pyflowater/__init__.py
@@ -332,6 +332,15 @@ class PyFlo:
         self._do_heartbeat()
         url = f"{FLO_V2_API_BASE}/session/firestore"
         data = self.query(url, method=METHOD_POST)
+        if data == None:
+            for i in range(3):
+                time.sleep(0.1)
+                data = self.query(url, method=METHOD_POST)
+                if data != None:
+                    break
+            if data == None:
+                LOG.warning(f"Failed to load data from {url}")
+                return None
         (location_id, mac_address) = self._get_locid_mac(device_id)
         return FloListener(
             heartbeat and self._do_heartbeat, data['token'], mac_address, callback


### PR DESCRIPTION
This implements a retry in the `get_real_time_listener()` method for when the data could not be accessed, for example, if it is experiencing network stability issues.

```py_flo.get_real_time_listener(id,callback)
File "/home/pi/.local/lib/python3.7/site-packages/pyflowater/init.py", line 337, in get_real_time_listener
heartbeat and self._do_heartbeat, data['token'], mac_address, callback
TypeError: 'NoneType' object is not subscriptable
```


https://github.com/yshao0712/FLO_water_analysis/issues/1

